### PR TITLE
fix: added write permissions to the docs task

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,12 +9,14 @@ on:
       - tests/**
       - hydromt_uwbm/**
       - docs/**
+      - .github/workflows/docs.yml
   pull_request:
     branches: [master]
     paths:
       - tests/**
       - hydromt_uwbm/**
       - docs/**
+      - .github/workflows/docs.yml
 
 jobs:
   docs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,15 +6,15 @@ on:
   push:
     branches: [master]
     paths:
-      - tests/*
-      - hydromt_uwbm/*
-      - docs/*
+      - tests/**
+      - hydromt_uwbm/**
+      - docs/**
   pull_request:
     branches: [master]
     paths:
-      - tests/*
-      - hydromt_uwbm/*
-      - docs/*
+      - tests/**
+      - hydromt_uwbm/**
+      - docs/**
 
 jobs:
   docs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,21 +17,20 @@ on:
       - docs/*
 
 jobs:
-  # Build docs on Linux
-  Docs:
+  docs:
     timeout-minutes: 10
-    name: linux docs
     runs-on: ubuntu-latest
-    env:
-      DOC_VERSION: dev
     defaults:
       run:
         shell: bash -l {0}
-    concurrency:
-      group:  ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
+    permissions:
+      contents: write
+      pages: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
       - uses: astral-sh/setup-uv@v7
       - uses: quarto-dev/quarto-actions/setup@v2
 


### PR DESCRIPTION
## Issue addressed
Fixes #5 

## Explanation
publishing to gh-pages requires write permissions

## Checklist
- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation if needed
- [ ] Updated changelog.rst if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
